### PR TITLE
fix(ci): make build-and-push-image trigger on direct master pushes; t…

### DIFF
--- a/.github/workflows/automated-checks.yml
+++ b/.github/workflows/automated-checks.yml
@@ -3,17 +3,12 @@ name: Automated Checks
 on:
   push:
     branches:
-      - '**'
-
+      - master
     tags-ignore:
       - '**'
-
   pull_request:
     branches:
-      - '**'
-
-    tags-ignore:
-      - '**'
+      - master
 
 jobs:
   # pre-commit Checks

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,8 +1,13 @@
 name: Build and publish Docker image
 
 on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
   pull_request:
-    branches: 
+    branches:
       - master
     types: [closed]
   workflow_dispatch:


### PR DESCRIPTION
## What this PR does

Fixes two broken CI behaviors in this repo.

### 1. `build-and-push-image.yml` now triggers on direct master pushes and version tags

**Before:** the workflow only fired on `pull_request: types: [closed]` (guarded by `pull_request.merged`) and `workflow_dispatch`. Direct pushes to `master` and tag pushes produced no image.

**Impact of the bug:** the daily `CompileList` workflow consumes the published container, so any config change pushed directly to master (admin bypass, emergency hotfix) never reached the daily list generation.

**After:** adds `push: branches: [master]` and `push: tags: [v*]` to the `on:` block. The existing `if: github.event.pull_request.merged` guard naturally filters non-merged PRs; direct pushes and tag pushes fall through because `github.event.pull_request` is null for them.

### 2. `automated-checks.yml` triggers tightened, invalid syntax removed

**Before:**
```yaml
on:
  push:
    branches: ['**']
    tags-ignore: ['**']
  pull_request:
    branches: ['**']
    tags-ignore: ['**']   # invalid: silently ignored on PR events
```

The `tags-ignore` under `pull_request` is rejected by GitHub (PRs don't carry tags), so the only effective filter was the over-broad `branches: ['**']` — pre-commit was firing on every feature/Dependabot branch.

**After:** both `push` and `pull_request` are scoped to `master`, and the invalid `tags-ignore` under `pull_request` is removed.

## Diff

```diff
 .github/workflows/automated-checks.yml     | 9 ++-------
 .github/workflows/build-and-push-image.yml | 7 ++++++-
 2 files changed, 8 insertions(+), 8 deletions(-)
```

## Testing

- Both files validated as YAML and re-loaded to confirm `on:` is well-formed.
- No behavioral change beyond the intended trigger widening (#1) and narrowing (#2).